### PR TITLE
fixed: the third character of asin is not a number

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ var asinParser = {
             return encapsulateReturn(urlOrPlainId);
         }
 
-        var parsed = urlOrPlainId.match(/https?:\/\/(www\.)?(.*)amazon\.([a-z\.]{2,6})(\/d\/(.*)|\/(.*)\/?(?:dp|o|gp|-)\/)(aw\/d\/|product\/)?(B[0-9]{2}[0-9A-Z]{7}|[0-9]{9}(?:X|[0-9]))/i);
+        var parsed = urlOrPlainId.match(/https?:\/\/(www\.)?(.*)amazon\.([a-z\.]{2,6})(\/d\/(.*)|\/(.*)\/?(?:dp|o|gp|-)\/)(aw\/d\/|product\/)?(B[0-9]{1}[0-9A-Z]{8}|[0-9]{9}(?:X|[0-9]))/i);
        
         if (parsed) {
             return encapsulateReturn(parsed.splice(-1)[0], urlOrPlainId);

--- a/test.js
+++ b/test.js
@@ -15,6 +15,15 @@ describe('amazonAsin', function () {
         });
 
         it('should return ASIN, rul, tld', function () {
+            var asin = amazonAsin.syncParseAsin("https://www.amazon.com/gp/product/B0B151JYPV");
+            assert.deepEqual(asin, {
+                ASIN: "B0B151JYPV",
+                url: "https://www.amazon.com/gp/product/B0B151JYPV",
+                urlTld: "com"
+            });
+        });
+
+        it('should return ASIN, rul, tld', function () {
             var asin = amazonAsin.syncParseAsin("https://www.amazon.co.uk/d/Hair-Gel/Eco-Styler-Olive-Oil-Styling/B003E7UNE4");
             assert.deepEqual(asin, {
                 ASIN: "B003E7UNE4",


### PR DESCRIPTION
The third character in some asins of Amazon's products launched in May is not a number 