### PR TITLE
Vaiden/a co support

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ var asinParser = {
     },
 
     asyncParseAsin: function (urlOrPlainId) {
-        var isPermaLink = /^https?:\/\/([a-zA-Z\d-]+\.){0,}amzn\.(to|eu)\//i.test(urlOrPlainId);
+        var isPermaLink = /^https?:\/\/([a-zA-Z\d-]+\.){0,}(amzn|a)\.(to|eu|co)\//i.test(urlOrPlainId);
         if (isPermaLink) {
             return redirectTracer(urlOrPlainId).then(function (resolvedUrl) {
                 return asinParser.syncParseAsin(resolvedUrl);

--- a/test.js
+++ b/test.js
@@ -117,7 +117,6 @@ describe('amazonAsin', function () {
                     }
                 );
             });
-
         });
     });
 

--- a/test.js
+++ b/test.js
@@ -107,6 +107,18 @@ describe('amazonAsin', function () {
                 );
             });
         });
+
+        it('should return ASIN, rul, tld (a.co shortened url)', function () {
+            return amazonAsin.asyncParseAsin("https://a.co/d/9DweDUD").then(function (result) {
+                assert.deepEqual(result, {
+                        ASIN: "B0B151JYPV",
+                        url: "https://www.amazon.com/dp/B0B151JYPV?ref_=cm_sw_r_cp_ud_dp_950J53CAK5EFM3659QQM",
+                        urlTld: "com"
+                    }
+                );
+            });
+
+        });
     });
 
 });


### PR DESCRIPTION
ADDED: Support for a.co (thanks to [@printscreen](https://github.com/printscreen))